### PR TITLE
Remove HTTP-basic and error 500 on login page

### DIFF
--- a/src/main/java/kg/attractor/xfood/config/SecurityConfig.java
+++ b/src/main/java/kg/attractor/xfood/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 	
 	private static final String[] WHITE_LIST_URL = {
 			"/auth/**",
+			"/DataTables/**",
+			"/js/validation.js",
 			"/css/layout.css",
 			"/appeal/**",
 			"/checks/**",

--- a/src/main/resources/templates/layout.ftlh
+++ b/src/main/resources/templates/layout.ftlh
@@ -19,6 +19,7 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
               integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
               crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
         <!-- Fontawesome CDN Link -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css">
@@ -124,7 +125,7 @@
                                    placeholder="Пароль должен быть не менее 8 символов, содержать цифры и буквы."/>
                         </div>
 
-                        <#if known??>
+                        <#if authorizedUser??>
                             <#if authorizedUser.authorities[0].authority??>
                                 <#if authorizedUser.authorities[0].authority == "ROLE_ADMIN" >
                                     <div class="mb-4">
@@ -179,7 +180,6 @@
             crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="/DataTables/datatables.min.js"></script>
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/i18n/ru.min.js"></script>
 


### PR DESCRIPTION
Removed HTTP-basic authentication before loading login page and fixed error 500 after a successful authentication.

 - Added some imports in layout.ftlh, which required authorization
 - Fixed check for an authorizedUser in freemarker